### PR TITLE
Add `solana` feature which allows to use the Merkle tree as an account

### DIFF
--- a/light-merkle-tree/Cargo.toml
+++ b/light-merkle-tree/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anchor-lang = { version = "0.25", optional = true }
 hasher = { path = "../../hasher" }
 
 [dev-dependencies]
 sha2 = "0.10"
+
+[features]
+solana = ["anchor-lang"]

--- a/light-merkle-tree/src/config.rs
+++ b/light-merkle-tree/src/config.rs
@@ -1,0 +1,26 @@
+#[cfg(feature = "solana")]
+use anchor_lang::prelude::*;
+
+use crate::constants::ZeroBytes;
+
+pub trait MerkleTreeConfig {
+    const ZERO_BYTES: ZeroBytes;
+    #[cfg(feature = "solana")]
+    const PROGRAM_ID: Pubkey;
+}
+
+#[cfg(not(feature = "solana"))]
+mod configs {
+    use super::*;
+
+    use crate::constants;
+
+    pub struct Sha256MerkleTreeConfig;
+
+    impl MerkleTreeConfig for Sha256MerkleTreeConfig {
+        const ZERO_BYTES: ZeroBytes = constants::sha256::ZERO_BYTES;
+    }
+}
+
+#[cfg(not(feature = "solana"))]
+pub use configs::*;

--- a/light-merkle-tree/src/lib.rs
+++ b/light-merkle-tree/src/lib.rs
@@ -1,6 +1,12 @@
-use constants::ZeroBytes;
+use std::marker::PhantomData;
+
+#[cfg(feature = "solana")]
+use anchor_lang::prelude::*;
 use hasher::{Hash, Hasher};
 
+use config::MerkleTreeConfig;
+
+pub mod config;
 pub mod constants;
 
 pub const DATA_LEN: usize = 32;
@@ -8,8 +14,20 @@ pub const HASH_LEN: usize = 32;
 pub const MAX_HEIGHT: usize = 18;
 pub const MERKLE_TREE_HISTORY_SIZE: usize = 256;
 
-#[derive(PartialEq, Eq, Debug)]
-pub struct MerkleTreeData {
+#[cfg(feature = "solana")]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Debug, Clone, Copy)]
+pub enum HashFunction {
+    Sha256,
+    Poseidon,
+}
+
+#[cfg_attr(feature = "solana", derive(AnchorSerialize, AnchorDeserialize))]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub struct MerkleTree<H, C>
+where
+    H: Hasher,
+    C: MerkleTreeConfig,
+{
     /// Height of the Merkle tree.
     pub height: usize,
     // TODO(vadorovsky): Check if Solana is OK with having a const generic
@@ -23,90 +41,77 @@ pub struct MerkleTreeData {
     pub next_index: usize,
     /// Current index of the root.
     pub current_root_index: usize,
+
+    /// Hash implementation used on the Merkle tree.
+    #[cfg(feature = "solana")]
+    pub hash_function: HashFunction,
+
+    hasher: PhantomData<H>,
+    config: PhantomData<C>,
 }
 
-pub struct MerkleTree<H>
+impl<H, C> MerkleTree<H, C>
 where
     H: Hasher,
+    C: MerkleTreeConfig,
 {
-    /// State of the Merkle tree stored as byte arrays.
-    pub data: MerkleTreeData,
-    /// sha256 hasher.
-    hasher: H,
-    /// Initial bytes of the Merkle tree (with all leaves having zero value).
-    zero_bytes: ZeroBytes,
-}
-
-impl<H> MerkleTree<H>
-where
-    H: Hasher,
-{
-    pub fn new(height: usize, hasher: H, zero_bytes: ZeroBytes) -> Self {
+    pub fn new(height: usize, #[cfg(feature = "solana")] hash_function: HashFunction) -> Self {
         assert!(height > 0);
         assert!(height <= MAX_HEIGHT);
 
         let mut filled_subtrees = [[0; HASH_LEN]; MAX_HEIGHT];
 
         for i in 0..height {
-            filled_subtrees[i] = zero_bytes[i];
+            filled_subtrees[i] = C::ZERO_BYTES[i];
         }
 
         let mut roots = [[0; HASH_LEN]; MERKLE_TREE_HISTORY_SIZE];
-        roots[0] = zero_bytes[height - 1];
+        roots[0] = C::ZERO_BYTES[height - 1];
 
         MerkleTree {
-            data: MerkleTreeData {
-                height,
-                filled_subtrees,
-                roots,
-                next_index: 0,
-                current_root_index: 0,
-            },
-            hasher,
-            zero_bytes,
-        }
-    }
-
-    pub fn from_data(data: MerkleTreeData, hasher: H, zero_bytes: ZeroBytes) -> Self {
-        MerkleTree {
-            data,
-            hasher,
-            zero_bytes,
+            height,
+            filled_subtrees,
+            roots,
+            next_index: 0,
+            current_root_index: 0,
+            #[cfg(feature = "solana")]
+            hash_function,
+            hasher: PhantomData,
+            config: PhantomData,
         }
     }
 
     pub fn hash(&mut self, leaf1: [u8; DATA_LEN], leaf2: [u8; DATA_LEN]) -> Hash {
-        self.hasher.hashv(&[&leaf1, &leaf2])
+        H::hashv(&[&leaf1, &leaf2])
     }
 
     pub fn insert(&mut self, leaf1: [u8; DATA_LEN], leaf2: [u8; DATA_LEN]) {
         // Check if next index doesn't exceed the Merkle tree capacity.
-        assert_ne!(self.data.next_index, 2usize.pow(self.data.height as u32));
+        assert_ne!(self.next_index, 2usize.pow(self.height as u32));
 
-        let mut current_index = self.data.next_index / 2;
+        let mut current_index = self.next_index / 2;
         let mut current_level_hash = self.hash(leaf1, leaf2);
 
-        for i in 1..self.data.height {
+        for i in 1..self.height {
             let (left, right) = if current_index % 2 == 0 {
-                self.data.filled_subtrees[i] = current_level_hash;
-                (current_level_hash, self.zero_bytes[i])
+                self.filled_subtrees[i] = current_level_hash;
+                (current_level_hash, C::ZERO_BYTES[i])
             } else {
-                (self.data.filled_subtrees[i], current_level_hash)
+                (self.filled_subtrees[i], current_level_hash)
             };
 
             current_index /= 2;
             current_level_hash = self.hash(left, right);
         }
 
-        self.data.current_root_index =
-            (self.data.current_root_index + 1) % MERKLE_TREE_HISTORY_SIZE;
-        self.data.roots[self.data.current_root_index] = current_level_hash;
-        self.data.next_index += 2;
+        self.current_root_index = (self.current_root_index + 1) % MERKLE_TREE_HISTORY_SIZE;
+        self.roots[self.current_root_index] = current_level_hash;
+        self.next_index += 2;
     }
 
     pub fn is_known_root(&self, root: [u8; HASH_LEN]) -> bool {
-        for i in (0..(self.data.current_root_index + 1)).rev() {
-            if self.data.roots[i] == root {
+        for i in (0..(self.current_root_index + 1)).rev() {
+            if self.roots[i] == root {
                 return true;
             }
         }
@@ -114,6 +119,17 @@ where
     }
 
     pub fn last_root(&self) -> [u8; HASH_LEN] {
-        self.data.roots[self.data.current_root_index]
+        self.roots[self.current_root_index]
+    }
+}
+
+#[cfg(feature = "solana")]
+impl<H, C> Owner for MerkleTree<H, C>
+where
+    H: Hasher,
+    C: MerkleTreeConfig,
+{
+    fn owner() -> Pubkey {
+        C::PROGRAM_ID
     }
 }

--- a/light-merkle-tree/tests/test.rs
+++ b/light-merkle-tree/tests/test.rs
@@ -1,11 +1,33 @@
 use hasher::solana::Sha256;
-use light_merkle_tree::{constants, MerkleTree};
+#[cfg(feature = "solana")]
+use light_merkle_tree::HashFunction;
+use light_merkle_tree::{
+    config,
+    constants::{self},
+    MerkleTree,
+};
+
+#[cfg(feature = "solana")]
+mod test_config {
+    use anchor_lang::prelude::*;
+
+    use super::*;
+
+    pub(crate) struct Sha256MerkleTreeConfig;
+
+    impl config::MerkleTreeConfig for Sha256MerkleTreeConfig {
+        const ZERO_BYTES: constants::ZeroBytes = constants::sha256::ZERO_BYTES;
+        const PROGRAM_ID: Pubkey = Pubkey::new_from_array([0u8; 32]);
+    }
+}
 
 #[test]
 fn test_sha256() {
-    let hasher = Sha256::new();
-    let zero_bytes = constants::sha256::ZERO_BYTES;
-    let mut merkle_tree = MerkleTree::new(3, hasher, zero_bytes);
+    #[cfg(feature = "solana")]
+    let mut merkle_tree =
+        MerkleTree::<Sha256, test_config::Sha256MerkleTreeConfig>::new(3, HashFunction::Sha256);
+    #[cfg(not(feature = "solana"))]
+    let mut merkle_tree = MerkleTree::<Sha256, config::Sha256MerkleTreeConfig>::new(3);
 
     let h = merkle_tree.hash([1; 32], [1; 32]);
     let h = merkle_tree.hash(h, h);
@@ -14,13 +36,15 @@ fn test_sha256() {
 
 #[test]
 fn test_merkle_tree_insert() {
-    let hasher = Sha256::new();
-    let zero_bytes = constants::sha256::ZERO_BYTES;
-    let mut merkle_tree = MerkleTree::new(3, hasher, zero_bytes);
+    #[cfg(feature = "solana")]
+    let mut merkle_tree =
+        MerkleTree::<Sha256, test_config::Sha256MerkleTreeConfig>::new(3, HashFunction::Sha256);
+    #[cfg(not(feature = "solana"))]
+    let mut merkle_tree = MerkleTree::<Sha256, config::Sha256MerkleTreeConfig>::new(3);
 
     let h1 = merkle_tree.hash([1; 32], [2; 32]);
-    let h2 = merkle_tree.hash(h1, zero_bytes[1]);
-    let h3 = merkle_tree.hash(h2, zero_bytes[2]);
+    let h2 = merkle_tree.hash(h1, constants::sha256::ZERO_BYTES[1]);
+    let h3 = merkle_tree.hash(h2, constants::sha256::ZERO_BYTES[2]);
 
     merkle_tree.insert([1u8; 32], [2u8; 32]);
     assert_eq!(merkle_tree.last_root(), h3);


### PR DESCRIPTION
After this change, building the crate with `--features solana` flag implements all Anchor traits which allow to store the `MerkleTree` struct as a field in Solana account.