### PR TITLE
Add `Hasher` trait and its implementations

### DIFF
--- a/light-merkle-tree/Cargo.toml
+++ b/light-merkle-tree/Cargo.toml
@@ -4,11 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anchor-lang = { version = "0.25", optional = true }
-hasher = { path = "../../hasher" }
+anchor-lang = "0.25"
 
 [dev-dependencies]
 sha2 = "0.10"
 
 [features]
-solana = ["anchor-lang"]
+solana = []

--- a/light-merkle-tree/src/hasher/blake3.rs
+++ b/light-merkle-tree/src/hasher/blake3.rs
@@ -1,0 +1,16 @@
+use anchor_lang::solana_program::blake3::{hash, hashv};
+
+use crate::{Hash, Hasher};
+
+#[derive(Clone, Copy)] // To allow using with zero copy Solana accounts.
+pub struct Blake3;
+
+impl Hasher for Blake3 {
+    fn hash(val: &[u8]) -> Hash {
+        hash(val).to_bytes()
+    }
+
+    fn hashv(vals: &[&[u8]]) -> Hash {
+        hashv(vals).to_bytes()
+    }
+}

--- a/light-merkle-tree/src/hasher/keccak.rs
+++ b/light-merkle-tree/src/hasher/keccak.rs
@@ -1,0 +1,16 @@
+use anchor_lang::solana_program::keccak::{hash, hashv};
+
+use crate::{Hash, Hasher};
+
+#[derive(Clone, Copy)] // To allow using with zero copy Solana accounts.
+pub struct Keccak;
+
+impl Hasher for Keccak {
+    fn hash(val: &[u8]) -> Hash {
+        hash(val).to_bytes()
+    }
+
+    fn hashv(vals: &[&[u8]]) -> Hash {
+        hashv(vals).to_bytes()
+    }
+}

--- a/light-merkle-tree/src/hasher/mod.rs
+++ b/light-merkle-tree/src/hasher/mod.rs
@@ -1,0 +1,16 @@
+pub mod blake3;
+pub mod keccak;
+pub mod sha256;
+
+pub use blake3::Blake3;
+pub use keccak::Keccak;
+pub use sha256::Sha256;
+
+pub const HASH_BYTES: usize = 32;
+
+pub type Hash = [u8; HASH_BYTES];
+
+pub trait Hasher {
+    fn hash(val: &[u8]) -> Hash;
+    fn hashv(vals: &[&[u8]]) -> Hash;
+}

--- a/light-merkle-tree/src/hasher/sha256.rs
+++ b/light-merkle-tree/src/hasher/sha256.rs
@@ -1,0 +1,16 @@
+use anchor_lang::solana_program::hash::{hash, hashv};
+
+use crate::{Hash, Hasher};
+
+#[derive(Clone, Copy)] // To allow using with zero copy Solana accounts.
+pub struct Sha256;
+
+impl Hasher for Sha256 {
+    fn hash(val: &[u8]) -> Hash {
+        hash(val).to_bytes()
+    }
+
+    fn hashv(vals: &[&[u8]]) -> Hash {
+        hashv(vals).to_bytes()
+    }
+}

--- a/light-merkle-tree/src/lib.rs
+++ b/light-merkle-tree/src/lib.rs
@@ -2,12 +2,13 @@ use std::marker::PhantomData;
 
 #[cfg(feature = "solana")]
 use anchor_lang::prelude::*;
-use hasher::{Hash, Hasher};
 
 use config::MerkleTreeConfig;
+use hasher::{Hash, Hasher};
 
 pub mod config;
 pub mod constants;
+pub mod hasher;
 
 pub const DATA_LEN: usize = 32;
 pub const HASH_LEN: usize = 32;

--- a/light-merkle-tree/tests/test.rs
+++ b/light-merkle-tree/tests/test.rs
@@ -1,9 +1,9 @@
-use hasher::solana::Sha256;
 #[cfg(feature = "solana")]
 use light_merkle_tree::HashFunction;
 use light_merkle_tree::{
     config,
     constants::{self},
+    hasher::Sha256,
     MerkleTree,
 };
 


### PR DESCRIPTION
We used to have a separate repo for that trait, but it's unlikely to be used anywhere outside the Merkle tree context, hence moving it here.

Starting from now, `anchor-lang` becomes a non-optional dependency of `light-merkle-tree`, **but** the `solana` feature still determines whether the `MerkleTree` struct implements `AnchorSerialize` and all the other traits needed for storing it in a Solana account.

Without `solana` feature, this crate is still not going to be usable for Solana programs, but rather only as a regular Rust crate to be used on host environments (mainly for testing). The only purpose of dependency on `anchor-lang` in that case is providing hash functions.