### PR TITLE
Add `init()` associated method (for `solana` feature)

### DIFF
--- a/light-merkle-tree/tests/test.rs
+++ b/light-merkle-tree/tests/test.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "solana")]
+use core::mem;
+
+#[cfg(feature = "solana")]
 use light_merkle_tree::HashFunction;
 use light_merkle_tree::{
     config,
@@ -24,8 +27,12 @@ mod test_config {
 #[test]
 fn test_sha256() {
     #[cfg(feature = "solana")]
-    let mut merkle_tree =
-        MerkleTree::<Sha256, test_config::Sha256MerkleTreeConfig>::new(3, HashFunction::Sha256);
+    let mut merkle_tree = {
+        let mut merkle_tree: MerkleTree<Sha256, test_config::Sha256MerkleTreeConfig> =
+            unsafe { mem::zeroed() };
+        merkle_tree.init(3, HashFunction::Sha256);
+        merkle_tree
+    };
     #[cfg(not(feature = "solana"))]
     let mut merkle_tree = MerkleTree::<Sha256, config::Sha256MerkleTreeConfig>::new(3);
 
@@ -37,8 +44,12 @@ fn test_sha256() {
 #[test]
 fn test_merkle_tree_insert() {
     #[cfg(feature = "solana")]
-    let mut merkle_tree =
-        MerkleTree::<Sha256, test_config::Sha256MerkleTreeConfig>::new(3, HashFunction::Sha256);
+    let mut merkle_tree = {
+        let mut merkle_tree: MerkleTree<Sha256, test_config::Sha256MerkleTreeConfig> =
+            unsafe { mem::zeroed() };
+        merkle_tree.init(3, HashFunction::Sha256);
+        merkle_tree
+    };
     #[cfg(not(feature = "solana"))]
     let mut merkle_tree = MerkleTree::<Sha256, config::Sha256MerkleTreeConfig>::new(3);
 


### PR DESCRIPTION
Calling the `new()` method doesn't make sense in Solana programs, because Anchor is already providing a mutable reference to a new account (annotated with `#[account(mut, init)]`), where the underlying memory is getting allocated and initialized with `core::mem::zeroed()`.

Therefore, what makes sense for Solana programs is having an `init()` method which initializes a zeroed account with data we want (height, subtrees, roots and hash function).