### PR TITLE
Update Solana SDK to 1.16 and Anchor to the latest change including it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+name: test
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        continue-on-error: true # WARNING: only for this example, remove it!
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        continue-on-error: true # WARNING: only for this example, remove it!
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/light-merkle-tree/Cargo.toml
+++ b/light-merkle-tree/Cargo.toml
@@ -6,7 +6,8 @@ description = "Sparse Merkle tree implementation"
 license = "Apache-2.0"
 
 [dependencies]
-anchor-lang = "0.26"
+anchor-lang = { git = "https://github.com/coral-xyz/anchor", rev = "1c6f86e5f7793ce6adefe9cbfa11939647c509ce" }
+bytemuck = "1.13.1"
 
 [dev-dependencies]
 sha2 = "0.10"


### PR DESCRIPTION
The newest solana-program crate was pulled unintentionally anyway which resulted in unexpected errors due to incompatibility of dependencies. More context: coral-xyz/anchor#2512